### PR TITLE
changed install section to correct package name

### DIFF
--- a/projects/cap-angular-widget/README.md
+++ b/projects/cap-angular-widget/README.md
@@ -15,7 +15,7 @@ An Angular 19+ Standalone Component wrapper for [CapJS](https://capjs.js.org/) â
 ## ðŸ“¦ Installation
 
 ```bash
-npm install cap-angular-widget
+npm install @espressotutorialsgmbh/cap-angular-widget
 ```
 
 Optional (falls nicht automatisch installiert):


### PR DESCRIPTION
I only got it installed via @espressotutorialsgmbh/cap-angular-widget, not cap-angular-widget

https://www.npmjs.com/package/@espressotutorialsgmbh/cap-angular-widget?activeTab=readme